### PR TITLE
ADD - Equipment 엔티티 추가

### DIFF
--- a/src/main/kotlin/com/linker/linkerapi/equipment/controller/EquipmentController.kt
+++ b/src/main/kotlin/com/linker/linkerapi/equipment/controller/EquipmentController.kt
@@ -1,0 +1,7 @@
+package com.linker.linkerapi.equipment.controller
+
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class EquipmentController {
+}

--- a/src/main/kotlin/com/linker/linkerapi/equipment/entity/Equipment.kt
+++ b/src/main/kotlin/com/linker/linkerapi/equipment/entity/Equipment.kt
@@ -1,0 +1,11 @@
+package com.linker.linkerapi.equipment.entity
+
+import com.linker.linkerapi.common.entity.BaseEntity
+import jakarta.persistence.Entity
+
+@Entity
+class Equipment(
+    var name: String,
+    var totalStock: Int,
+    var availableStock: Int,
+):BaseEntity()

--- a/src/main/kotlin/com/linker/linkerapi/equipment/repository/EquipmentRepository.kt
+++ b/src/main/kotlin/com/linker/linkerapi/equipment/repository/EquipmentRepository.kt
@@ -1,0 +1,6 @@
+package com.linker.linkerapi.equipment.repository
+
+import com.linker.linkerapi.equipment.entity.Equipment
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface EquipmentRepository: JpaRepository<Equipment, Long>

--- a/src/main/kotlin/com/linker/linkerapi/equipment/service/EquipmentService.kt
+++ b/src/main/kotlin/com/linker/linkerapi/equipment/service/EquipmentService.kt
@@ -1,0 +1,7 @@
+package com.linker.linkerapi.equipment.service
+
+import org.springframework.stereotype.Service
+
+@Service
+class EquipmentService {
+}

--- a/src/main/resources/db/changelog/2025/01/27-01-changelog.yaml
+++ b/src/main/resources/db/changelog/2025/01/27-01-changelog.yaml
@@ -1,0 +1,37 @@
+databaseChangeLog:
+  - changeSet:
+      id: 1737981604957-1
+      author: ji-inpark
+      objectQuotingStrategy: QUOTE_ONLY_RESERVED_WORDS
+      changes:
+        - createTable:
+            columns:
+              - column:
+                  autoIncrement: true
+                  constraints:
+                    nullable: false
+                    primaryKey: true
+                    primaryKeyName: pk_equipment
+                  name: id
+                  type: BIGINT
+              - column:
+                  name: created_at
+                  type: DATETIME
+              - column:
+                  name: updated_at
+                  type: DATETIME
+              - column:
+                  name: name
+                  type: VARCHAR(255)
+              - column:
+                  constraints:
+                    nullable: false
+                  name: total_stock
+                  type: INT
+              - column:
+                  constraints:
+                    nullable: false
+                  name: available_stock
+                  type: INT
+            tableName: equipment
+


### PR DESCRIPTION
## 📚 개요

- Equipment 엔티티를 추가했습니다.
- 또한 기본으로 사용되는 controller, service, repository도 구조만 만들어뒀습니다.

## 🕐 리뷰 예상 시간

> 5m

## ❗❗ 중요한 변경점(Option)

liquibase를 사용해서 db 형상관리를 진행하고 있습니다. 해당 브랜치로 스프링을 한 번 실행시키면 database 테이블에 equipment 테이블이 생긴 것을 확인할 수 있습니다.