### PR TITLE
feat : 대여 가능한 기자재 조회 API 추가 (EquipmentController, EquipmentService 수정)

### DIFF
--- a/src/main/kotlin/com/linker/linkerapi/equipment/controller/EquipmentController.kt
+++ b/src/main/kotlin/com/linker/linkerapi/equipment/controller/EquipmentController.kt
@@ -1,7 +1,20 @@
 package com.linker.linkerapi.equipment.controller
 
+import com.linker.linkerapi.equipment.entity.Equipment
+import com.linker.linkerapi.equipment.service.EquipmentService
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
-class EquipmentController {
+@RequestMapping("/api/equipments")
+class EquipmentController(
+    private val equipmentService: EquipmentService
+) {
+    @GetMapping("/available")
+    fun getAvailableEquipments(): ResponseEntity<List<Equipment>> {
+        val availableEquipments: List<Equipment> = equipmentService.getAvailableEquipment()
+        return ResponseEntity.ok(availableEquipments)
+    }
 }

--- a/src/main/kotlin/com/linker/linkerapi/equipment/controller/EquipmentController.kt
+++ b/src/main/kotlin/com/linker/linkerapi/equipment/controller/EquipmentController.kt
@@ -2,19 +2,20 @@ package com.linker.linkerapi.equipment.controller
 
 import com.linker.linkerapi.equipment.entity.Equipment
 import com.linker.linkerapi.equipment.service.EquipmentService
-import org.springframework.http.ResponseEntity
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
+@Tag(name = "Equipment Controller")
 @RestController
-@RequestMapping("/api/equipments")
 class EquipmentController(
     private val equipmentService: EquipmentService
 ) {
-    @GetMapping("/available")
-    fun getAvailableEquipments(): ResponseEntity<List<Equipment>> {
-        val availableEquipments: List<Equipment> = equipmentService.getAvailableEquipment()
-        return ResponseEntity.ok(availableEquipments)
+    @Operation(summary = "기자재 조회", description = "저장되어 있는 모든 기자재를 조회합니다.")
+    @GetMapping("/equipments")
+    fun getEquipments(): List<Equipment> {
+        val equipments = equipmentService.getEquipments()
+        return equipments
     }
 }

--- a/src/main/kotlin/com/linker/linkerapi/equipment/service/EquipmentService.kt
+++ b/src/main/kotlin/com/linker/linkerapi/equipment/service/EquipmentService.kt
@@ -1,7 +1,13 @@
 package com.linker.linkerapi.equipment.service
 
+import com.linker.linkerapi.equipment.entity.Equipment
+import com.linker.linkerapi.equipment.repository.EquipmentRepository
 import org.springframework.stereotype.Service
 
 @Service
-class EquipmentService {
+class EquipmentService(
+    private val equipmentRepository: EquipmentRepository) {
+        fun getAvailableEquipment(): List<Equipment> {
+            return equipmentRepository.findAll().filter { it.availableStock>0 }
+        }
 }

--- a/src/main/kotlin/com/linker/linkerapi/equipment/service/EquipmentService.kt
+++ b/src/main/kotlin/com/linker/linkerapi/equipment/service/EquipmentService.kt
@@ -6,8 +6,9 @@ import org.springframework.stereotype.Service
 
 @Service
 class EquipmentService(
-    private val equipmentRepository: EquipmentRepository) {
-        fun getAvailableEquipment(): List<Equipment> {
-            return equipmentRepository.findAll().filter { it.availableStock>0 }
-        }
+    private val equipmentRepository: EquipmentRepository
+) {
+    fun getEquipments(): List<Equipment> {
+        return equipmentRepository.findAll()
+    }
 }


### PR DESCRIPTION
## 📚 개요

대여 가능한 기자재 조회 API를 구현했습니다

## 🕐 리뷰 예상 시간

10-15min

## ❗❗ 중요한 변경점(Option)

- EquipmentController에 /api/equipments/available 엔드포인트를 추가해서 클라이언트가 대여 가능한 기자재 목록을 조회할 수 있도록 했습니다.

- EquipmentService에서는 EquipmentRepository로부터 전체 기자재를 조회한 후, availableStock이 0보다 큰 기자재만 필터링하게 로직을 구현했습니다.