### PR TITLE
ADD - Rental용 liquibase changelog 추가

### DIFF
--- a/src/main/resources/db/changelog/2025/02/26-01-changelog.yaml
+++ b/src/main/resources/db/changelog/2025/02/26-01-changelog.yaml
@@ -1,0 +1,55 @@
+databaseChangeLog:
+  - changeSet:
+      id: 1740567258041-1
+      author: ji-inpark
+      objectQuotingStrategy: QUOTE_ONLY_RESERVED_WORDS
+      changes:
+        - createTable:
+            columns:
+              - column:
+                  autoIncrement: true
+                  constraints:
+                    nullable: false
+                    primaryKey: true
+                    primaryKeyName: pk_rental
+                  name: id
+                  type: BIGINT
+              - column:
+                  name: created_at
+                  type: DATETIME
+              - column:
+                  name: updated_at
+                  type: DATETIME
+              - column:
+                  name: equipment_id
+                  type: BIGINT
+              - column:
+                  name: phone_number
+                  type: VARCHAR(255)
+              - column:
+                  name: name
+                  type: VARCHAR(255)
+              - column:
+                  constraints:
+                    nullable: false
+                  name: student_id
+                  type: BIGINT
+              - column:
+                  name: rental_type
+                  type: SMALLINT
+              - column:
+                  name: status
+                  type: SMALLINT
+            tableName: rental
+  - changeSet:
+      id: 1740567258041-2
+      author: ji-inpark
+      objectQuotingStrategy: QUOTE_ONLY_RESERVED_WORDS
+      changes:
+        - addForeignKeyConstraint:
+            baseColumnNames: equipment_id
+            baseTableName: rental
+            constraintName: FK_RENTAL_ON_EQUIPMENT
+            referencedColumnNames: id
+            referencedTableName: equipment
+


### PR DESCRIPTION
## 📚 개요

- db에 rental 테이블을 추가하기 위한 liquibase changelog를 추가했습니다.

## 🕐 리뷰 예상 시간

> 1m

## ❗❗ 중요한 변경점(Option)

rental 클래스를 기반으로 자동 생성된 파일이니 제대로 보실 필요는 없고, 이 브랜치에서 서버 실행시켰을 때 db에 테이블이 제대로 생겼는지만 확인하시면 됩니다.