### PR TITLE
fix : coolsms 문자 길이 해결

### DIFF
--- a/src/main/kotlin/com/linker/linkerapi/notification/service/SmsService.kt
+++ b/src/main/kotlin/com/linker/linkerapi/notification/service/SmsService.kt
@@ -22,7 +22,7 @@ class SmsService(
         val params = HashMap<String, String>()
         params["to"] = phoneNumber
         params["from"] = senderNumber
-        params["type"] = "SMS"
+        params["type"] = "LMS"
         params["text"] = content
 
         return coolsms.send(params)


### PR DESCRIPTION
## 📚 개요

기존 SMS 형식은 80바이트 제한이 있어, 형식을 LMS로 변경했습니다.

## 🕐 리뷰 예상 시간

> 0m

## ❗❗ 중요한 변경점(Option)