### PR TITLE
Feat: 사물함 대여 및 관리 기능 추가

### DIFF
--- a/src/main/kotlin/com/linker/linkerapi/LinkerApiApplication.kt
+++ b/src/main/kotlin/com/linker/linkerapi/LinkerApiApplication.kt
@@ -1,11 +1,8 @@
 package com.linker.linkerapi
 
-import com.linker.linkerapi.locker.service.LockerService
 import jakarta.annotation.PostConstruct
-import org.springframework.boot.CommandLineRunner
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
-import org.springframework.context.annotation.Bean
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing
 import org.springframework.scheduling.annotation.EnableScheduling
 import java.util.*
@@ -17,11 +14,6 @@ class LinkerApiApplication {
     @PostConstruct
     fun started() {
         TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"))
-    }
-
-    @Bean
-    fun init(lockerService: LockerService) = CommandLineRunner {
-        lockerService.initializeLockerData()
     }
 }
 

--- a/src/main/kotlin/com/linker/linkerapi/LinkerApiApplication.kt
+++ b/src/main/kotlin/com/linker/linkerapi/LinkerApiApplication.kt
@@ -1,8 +1,11 @@
 package com.linker.linkerapi
 
+import com.linker.linkerapi.locker.service.LockerService
 import jakarta.annotation.PostConstruct
+import org.springframework.boot.CommandLineRunner
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
+import org.springframework.context.annotation.Bean
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing
 import org.springframework.scheduling.annotation.EnableScheduling
 import java.util.*
@@ -14,6 +17,11 @@ class LinkerApiApplication {
     @PostConstruct
     fun started() {
         TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"))
+    }
+
+    @Bean
+    fun init(lockerService: LockerService) = CommandLineRunner {
+        lockerService.initializeLockerData()
     }
 }
 

--- a/src/main/kotlin/com/linker/linkerapi/locker/controller/AdminLockerController.kt
+++ b/src/main/kotlin/com/linker/linkerapi/locker/controller/AdminLockerController.kt
@@ -1,0 +1,23 @@
+package com.linker.linkerapi.locker.controller
+
+import com.linker.linkerapi.common.annotation.AdminUsername
+import com.linker.linkerapi.locker.dto.LockerResponse
+import com.linker.linkerapi.locker.dto.UpdateLockerStatusRequest
+import com.linker.linkerapi.locker.service.LockerService
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.web.bind.annotation.*
+
+@Tag(name = "Admin Locker Controller")
+@RestController
+@RequestMapping("/admin/lockers")
+class AdminLockerController(private val lockerService: LockerService) {
+
+    @Operation(summary = "사물함 상태 변경")
+    @PatchMapping("/{lockerId}/status")
+    fun updateLockerStatus(
+        @AdminUsername username: String,
+        @PathVariable lockerId: Long,
+        @RequestBody request: UpdateLockerStatusRequest
+    ): LockerResponse = lockerService.updateLockerStatus(lockerId, request.status)
+}

--- a/src/main/kotlin/com/linker/linkerapi/locker/controller/LockerController.kt
+++ b/src/main/kotlin/com/linker/linkerapi/locker/controller/LockerController.kt
@@ -1,0 +1,38 @@
+package com.linker.linkerapi.locker.controller
+
+import com.linker.linkerapi.locker.dto.LockerResponse
+import com.linker.linkerapi.locker.service.LockerService
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.*
+
+@Tag(name = "Locker Controller")
+@RestController
+@RequestMapping("/lockers")
+class LockerController(private val lockerService: LockerService) {
+
+    @Operation(summary = "모든 사물함 조회")
+    @GetMapping
+    fun getAllLockers(): List<LockerResponse> = lockerService.getAllLockers()
+
+    @Operation(summary = "학번으로 내 사물함 조회")
+    @GetMapping("/my")
+    fun getMyLocker(@RequestParam studentId: Long): LockerResponse =
+        lockerService.getLockerByStudentId(studentId)
+
+    @Operation(summary = "사물함 대여")
+    @PostMapping("/{lockerId}/rent")
+    @ResponseStatus(HttpStatus.CREATED)
+    fun rentLocker(
+        @PathVariable lockerId: Long,
+        @RequestParam studentId: Long
+    ): LockerResponse = lockerService.rentLocker(lockerId, studentId)
+
+    @Operation(summary = "사물함 반납")
+    @PostMapping("/return")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    fun returnLocker(@RequestParam studentId: Long) {
+        lockerService.returnLocker(studentId)
+    }
+}

--- a/src/main/kotlin/com/linker/linkerapi/locker/dto/LockerResponse.kt
+++ b/src/main/kotlin/com/linker/linkerapi/locker/dto/LockerResponse.kt
@@ -1,0 +1,22 @@
+package com.linker.linkerapi.locker.dto
+
+import com.linker.linkerapi.locker.entity.Locker
+import com.linker.linkerapi.locker.enums.LockerStatus
+
+data class LockerResponse(
+    val id: Long,
+    val lockerName: String,
+    val location: String,
+    val status: LockerStatus,
+    val studentId: Long?
+) {
+    companion object {
+        fun from(locker: Locker) = LockerResponse(
+            id = locker.id,
+            lockerName = locker.lockerName,
+            location = locker.location,
+            status = locker.status,
+            studentId = locker.studentId
+        )
+    }
+}

--- a/src/main/kotlin/com/linker/linkerapi/locker/dto/LockerResponse.kt
+++ b/src/main/kotlin/com/linker/linkerapi/locker/dto/LockerResponse.kt
@@ -7,16 +7,14 @@ data class LockerResponse(
     val id: Long,
     val lockerName: String,
     val location: String,
-    val status: LockerStatus,
-    val studentId: Long?
+    val status: LockerStatus
 ) {
     companion object {
         fun from(locker: Locker) = LockerResponse(
             id = locker.id,
             lockerName = locker.lockerName,
             location = locker.location,
-            status = locker.status,
-            studentId = locker.studentId
+            status = locker.status
         )
     }
 }

--- a/src/main/kotlin/com/linker/linkerapi/locker/dto/UpdateLockerStatusRequest.kt
+++ b/src/main/kotlin/com/linker/linkerapi/locker/dto/UpdateLockerStatusRequest.kt
@@ -1,0 +1,7 @@
+package com.linker.linkerapi.locker.dto
+
+import com.linker.linkerapi.locker.enums.LockerStatus
+
+data class UpdateLockerStatusRequest(
+    val status: LockerStatus
+)

--- a/src/main/kotlin/com/linker/linkerapi/locker/entity/Locker.kt
+++ b/src/main/kotlin/com/linker/linkerapi/locker/entity/Locker.kt
@@ -1,0 +1,16 @@
+package com.linker.linkerapi.locker.entity
+
+import com.linker.linkerapi.common.entity.BaseEntity
+import com.linker.linkerapi.locker.enums.LockerStatus
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+
+@Entity
+class Locker(
+    val lockerName: String,
+    val location: String,
+    @Enumerated(EnumType.STRING)
+    var status: LockerStatus = LockerStatus.AVAILABLE,
+    var studentId: Long? = null
+) : BaseEntity()

--- a/src/main/kotlin/com/linker/linkerapi/locker/enums/LockerStatus.kt
+++ b/src/main/kotlin/com/linker/linkerapi/locker/enums/LockerStatus.kt
@@ -1,0 +1,7 @@
+package com.linker.linkerapi.locker.enums
+
+enum class LockerStatus {
+    AVAILABLE,
+    RENTED,
+    BROKEN
+}

--- a/src/main/kotlin/com/linker/linkerapi/locker/exception/LockerAlreadyRentedException.kt
+++ b/src/main/kotlin/com/linker/linkerapi/locker/exception/LockerAlreadyRentedException.kt
@@ -1,0 +1,7 @@
+package com.linker.linkerapi.locker.exception
+
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.ResponseStatus
+
+@ResponseStatus(code = HttpStatus.CONFLICT, reason = "이미 사물함을 대여했거나, 해당 사물함은 대여할 수 없는 상태입니다.")
+class LockerAlreadyRentedException : RuntimeException()

--- a/src/main/kotlin/com/linker/linkerapi/locker/exception/LockerNotFoundException.kt
+++ b/src/main/kotlin/com/linker/linkerapi/locker/exception/LockerNotFoundException.kt
@@ -1,0 +1,7 @@
+package com.linker.linkerapi.locker.exception
+
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.ResponseStatus
+
+@ResponseStatus(code = HttpStatus.NOT_FOUND, reason = "사물함 정보를 찾을 수 없습니다.")
+class LockerNotFoundException : RuntimeException()

--- a/src/main/kotlin/com/linker/linkerapi/locker/repository/LockerRepository.kt
+++ b/src/main/kotlin/com/linker/linkerapi/locker/repository/LockerRepository.kt
@@ -1,0 +1,8 @@
+package com.linker.linkerapi.locker.repository
+
+import com.linker.linkerapi.locker.entity.Locker
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface LockerRepository : JpaRepository<Locker, Long> {
+    fun findByStudentId(studentId: Long): Locker?
+}

--- a/src/main/kotlin/com/linker/linkerapi/locker/service/LockerService.kt
+++ b/src/main/kotlin/com/linker/linkerapi/locker/service/LockerService.kt
@@ -23,6 +23,14 @@ class LockerService(private val lockerRepository: LockerRepository) {
 
     @Transactional
     fun rentLocker(lockerId: Long, studentId: Long): LockerResponse {
+        val locker = validateRentalRequest(lockerId, studentId)
+
+        locker.status = LockerStatus.RENTED
+        locker.studentId = studentId
+        return LockerResponse.from(lockerRepository.save(locker))
+    }
+
+    private fun validateRentalRequest(lockerId: Long, studentId: Long): Locker {
         lockerRepository.findByStudentId(studentId)?.let {
             throw LockerAlreadyRentedException()
         }
@@ -33,10 +41,7 @@ class LockerService(private val lockerRepository: LockerRepository) {
         if (locker.status != LockerStatus.AVAILABLE) {
             throw LockerAlreadyRentedException()
         }
-
-        locker.status = LockerStatus.RENTED
-        locker.studentId = studentId
-        return LockerResponse.from(lockerRepository.save(locker))
+        return locker
     }
 
     @Transactional
@@ -59,59 +64,5 @@ class LockerService(private val lockerRepository: LockerRepository) {
             locker.studentId = null
         }
         return LockerResponse.from(lockerRepository.save(locker))
-    }
-
-    // 초기 사물함 데이터 생성
-    fun initializeLockerData() {
-        if (lockerRepository.count() > 0) return
-
-        val lockers = mutableListOf<Locker>()
-
-        // A동 301호 앞(과방)
-        for (i in 10..54) {
-            lockers.add(Locker("3a$i", "A동 301호 앞(과방)"))
-        }
-
-        // A동 3층 계단 앞
-        for (i in 55..63) {
-            lockers.add(Locker("3a$i", "A동 3층 계단 앞"))
-        }
-
-        // A동 2층 217호 앞(서점쪽 계단)
-        for (i in 28..36) {
-            lockers.add(Locker("2c$i", "A동 2층 217호 앞(서점쪽 계단)"))
-        }
-
-        // B동 3층 중앙계단
-        for (i in 1..18) {
-            lockers.add(Locker("3b${String.format("%02d", i)}", "B동 3층 중앙계단"))
-        }
-
-        // B동 안뜰로 가는 통로
-        for (i in 1..57) {
-            lockers.add(Locker("1a${String.format("%02d", i)}", "B동 안뜰로 가는 통로"))
-        }
-
-        // C동 3층 경사로(352-2호 앞)
-        for (i in 1..36) {
-            lockers.add(Locker("3c${String.format("%02d", i)}", "C동 3층 경사로(352-2호 앞)"))
-        }
-
-        // C동 3층 중앙 계단
-        for (i in 37..54) {
-            lockers.add(Locker("3c${String.format("%02d", i)}", "C동 3층 중앙 계단"))
-        }
-
-        // C동 끝 3~4층 계단
-        for (i in 55..117) {
-            lockers.add(Locker("3c${String.format("%02d", i)}", "C동 끝 3~4층 계단"))
-        }
-
-        // A,C동 넘어가는 계단 앞
-        for (i in 1..27) {
-            lockers.add(Locker("2c${String.format("%02d", i)}", "A,C동 넘어가는 계단 앞"))
-        }
-
-        lockerRepository.saveAll(lockers)
     }
 }

--- a/src/main/kotlin/com/linker/linkerapi/locker/service/LockerService.kt
+++ b/src/main/kotlin/com/linker/linkerapi/locker/service/LockerService.kt
@@ -1,0 +1,117 @@
+package com.linker.linkerapi.locker.service
+
+import com.linker.linkerapi.locker.dto.LockerResponse
+import com.linker.linkerapi.locker.entity.Locker
+import com.linker.linkerapi.locker.enums.LockerStatus
+import com.linker.linkerapi.locker.exception.LockerAlreadyRentedException
+import com.linker.linkerapi.locker.exception.LockerNotFoundException
+import com.linker.linkerapi.locker.repository.LockerRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class LockerService(private val lockerRepository: LockerRepository) {
+
+    fun getAllLockers(): List<LockerResponse> =
+        lockerRepository.findAll().map { LockerResponse.from(it) }
+
+    fun getLockerByStudentId(studentId: Long): LockerResponse {
+        val locker = lockerRepository.findByStudentId(studentId)
+            ?: throw LockerNotFoundException()
+        return LockerResponse.from(locker)
+    }
+
+    @Transactional
+    fun rentLocker(lockerId: Long, studentId: Long): LockerResponse {
+        lockerRepository.findByStudentId(studentId)?.let {
+            throw LockerAlreadyRentedException()
+        }
+
+        val locker = lockerRepository.findById(lockerId)
+            .orElseThrow { LockerNotFoundException() }
+
+        if (locker.status != LockerStatus.AVAILABLE) {
+            throw LockerAlreadyRentedException()
+        }
+
+        locker.status = LockerStatus.RENTED
+        locker.studentId = studentId
+        return LockerResponse.from(lockerRepository.save(locker))
+    }
+
+    @Transactional
+    fun returnLocker(studentId: Long) {
+        val locker = lockerRepository.findByStudentId(studentId)
+            ?: throw LockerNotFoundException()
+
+        locker.status = LockerStatus.AVAILABLE
+        locker.studentId = null
+        lockerRepository.save(locker)
+    }
+
+    @Transactional
+    fun updateLockerStatus(lockerId: Long, status: LockerStatus): LockerResponse {
+        val locker = lockerRepository.findById(lockerId)
+            .orElseThrow { LockerNotFoundException() }
+
+        locker.status = status
+        if (status == LockerStatus.AVAILABLE) {
+            locker.studentId = null
+        }
+        return LockerResponse.from(lockerRepository.save(locker))
+    }
+
+    // 초기 사물함 데이터 생성
+    fun initializeLockerData() {
+        if (lockerRepository.count() > 0) return
+
+        val lockers = mutableListOf<Locker>()
+
+        // A동 301호 앞(과방)
+        for (i in 10..54) {
+            lockers.add(Locker("3a$i", "A동 301호 앞(과방)"))
+        }
+
+        // A동 3층 계단 앞
+        for (i in 55..63) {
+            lockers.add(Locker("3a$i", "A동 3층 계단 앞"))
+        }
+
+        // A동 2층 217호 앞(서점쪽 계단)
+        for (i in 28..36) {
+            lockers.add(Locker("2c$i", "A동 2층 217호 앞(서점쪽 계단)"))
+        }
+
+        // B동 3층 중앙계단
+        for (i in 1..18) {
+            lockers.add(Locker("3b${String.format("%02d", i)}", "B동 3층 중앙계단"))
+        }
+
+        // B동 안뜰로 가는 통로
+        for (i in 1..57) {
+            lockers.add(Locker("1a${String.format("%02d", i)}", "B동 안뜰로 가는 통로"))
+        }
+
+        // C동 3층 경사로(352-2호 앞)
+        for (i in 1..36) {
+            lockers.add(Locker("3c${String.format("%02d", i)}", "C동 3층 경사로(352-2호 앞)"))
+        }
+
+        // C동 3층 중앙 계단
+        for (i in 37..54) {
+            lockers.add(Locker("3c${String.format("%02d", i)}", "C동 3층 중앙 계단"))
+        }
+
+        // C동 끝 3~4층 계단
+        for (i in 55..117) {
+            lockers.add(Locker("3c${String.format("%02d", i)}", "C동 끝 3~4층 계단"))
+        }
+
+        // A,C동 넘어가는 계단 앞
+        for (i in 1..27) {
+            lockers.add(Locker("2c${String.format("%02d", i)}", "A,C동 넘어가는 계단 앞"))
+        }
+
+        lockerRepository.saveAll(lockers)
+    }
+}

--- a/src/main/resources/db/changelog/2025/09/13-01-changelog.yaml
+++ b/src/main/resources/db/changelog/2025/09/13-01-changelog.yaml
@@ -1,0 +1,33 @@
+databaseChangeLog:
+  - changeSet:
+      id: 20250913-1
+      author: wook
+      changes:
+        - createTable:
+            tableName: locker
+            columns:
+              - column:
+                  name: id
+                  type: BIGINT
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: created_at
+                  type: DATETIME
+              - column:
+                  name: updated_at
+                  type: DATETIME
+              - column:
+                  name: locker_name
+                  type: VARCHAR(255)
+              - column:
+                  name: location
+                  type: VARCHAR(255)
+              - column:
+                  name: status
+                  type: VARCHAR(255)
+              - column:
+                  name: student_id
+                  type: BIGINT

--- a/src/main/resources/db/changelog/2025/09/14-01-changelog.yaml
+++ b/src/main/resources/db/changelog/2025/09/14-01-changelog.yaml
@@ -1,0 +1,16 @@
+databaseChangeLog:
+  - changeSet:
+      id: 20250914-1
+      author: wook
+      comment: "Load initial locker data from csv"
+      changes:
+        - loadData:
+            tableName: locker
+            file: db/data/lockers.csv
+            encoding: UTF-8
+            separator: ','
+            quotchar: '"'
+            columns:
+              - column: { header: "locker_name", name: "locker_name", type: "STRING" }
+              - column: { header: "location", name: "location", type: "STRING" }
+              - column: { header: "status", name: "status", type: "STRING" }

--- a/src/main/resources/db/data/lockers.csv
+++ b/src/main/resources/db/data/lockers.csv
@@ -1,0 +1,283 @@
+locker_name,location,status
+3a10,A동 301호 앞(과방),AVAILABLE
+3a11,A동 301호 앞(과방),AVAILABLE
+3a12,A동 301호 앞(과방),AVAILABLE
+3a13,A동 301호 앞(과방),AVAILABLE
+3a14,A동 301호 앞(과방),AVAILABLE
+3a15,A동 301호 앞(과방),AVAILABLE
+3a16,A동 301호 앞(과방),AVAILABLE
+3a17,A동 301호 앞(과방),AVAILABLE
+3a18,A동 301호 앞(과방),AVAILABLE
+3a19,A동 301호 앞(과방),AVAILABLE
+3a20,A동 301호 앞(과방),AVAILABLE
+3a21,A동 301호 앞(과방),AVAILABLE
+3a22,A동 301호 앞(과방),AVAILABLE
+3a23,A동 301호 앞(과방),AVAILABLE
+3a24,A동 301호 앞(과방),AVAILABLE
+3a25,A동 301호 앞(과방),AVAILABLE
+3a26,A동 301호 앞(과방),AVAILABLE
+3a27,A동 301호 앞(과방),AVAILABLE
+3a28,A동 301호 앞(과방),AVAILABLE
+3a29,A동 301호 앞(과방),AVAILABLE
+3a30,A동 301호 앞(과방),AVAILABLE
+3a31,A동 301호 앞(과방),AVAILABLE
+3a32,A동 301호 앞(과방),AVAILABLE
+3a33,A동 301호 앞(과방),AVAILABLE
+3a34,A동 301호 앞(과방),AVAILABLE
+3a35,A동 301호 앞(과방),AVAILABLE
+3a36,A동 301호 앞(과방),AVAILABLE
+3a37,A동 301호 앞(과방),AVAILABLE
+3a38,A동 301호 앞(과방),AVAILABLE
+3a39,A동 301호 앞(과방),AVAILABLE
+3a40,A동 301호 앞(과방),AVAILABLE
+3a41,A동 301호 앞(과방),AVAILABLE
+3a42,A동 301호 앞(과방),AVAILABLE
+3a43,A동 301호 앞(과방),AVAILABLE
+3a44,A동 301호 앞(과방),AVAILABLE
+3a45,A동 301호 앞(과방),AVAILABLE
+3a46,A동 301호 앞(과방),AVAILABLE
+3a47,A동 301호 앞(과방),AVAILABLE
+3a48,A동 301호 앞(과방),AVAILABLE
+3a49,A동 301호 앞(과방),AVAILABLE
+3a50,A동 301호 앞(과방),AVAILABLE
+3a51,A동 301호 앞(과방),AVAILABLE
+3a52,A동 301호 앞(과방),AVAILABLE
+3a53,A동 301호 앞(과방),AVAILABLE
+3a54,A동 301호 앞(과방),AVAILABLE
+3a55,A동 3층 계단 앞,AVAILABLE
+3a56,A동 3층 계단 앞,AVAILABLE
+3a57,A동 3층 계단 앞,AVAILABLE
+3a58,A동 3층 계단 앞,AVAILABLE
+3a59,A동 3층 계단 앞,AVAILABLE
+3a60,A동 3층 계단 앞,AVAILABLE
+3a61,A동 3층 계단 앞,AVAILABLE
+3a62,A동 3층 계단 앞,AVAILABLE
+3a63,A동 3층 계단 앞,AVAILABLE
+2c28,A동 2층 217호 앞(서점쪽 계단),AVAILABLE
+2c29,A동 2층 217호 앞(서점쪽 계단),AVAILABLE
+2c30,A동 2층 217호 앞(서점쪽 계단),AVAILABLE
+2c31,A동 2층 217호 앞(서점쪽 계단),AVAILABLE
+2c32,A동 2층 217호 앞(서점쪽 계단),AVAILABLE
+2c33,A동 2층 217호 앞(서점쪽 계단),AVAILABLE
+2c34,A동 2층 217호 앞(서점쪽 계단),AVAILABLE
+2c35,A동 2층 217호 앞(서점쪽 계단),AVAILABLE
+2c36,A동 2층 217호 앞(서점쪽 계단),AVAILABLE
+3b01,B동 3층 중앙계단,AVAILABLE
+3b02,B동 3층 중앙계단,AVAILABLE
+3b03,B동 3층 중앙계단,AVAILABLE
+3b04,B동 3층 중앙계단,AVAILABLE
+3b05,B동 3층 중앙계단,AVAILABLE
+3b06,B동 3층 중앙계단,AVAILABLE
+3b07,B동 3층 중앙계단,AVAILABLE
+3b08,B동 3층 중앙계단,AVAILABLE
+3b09,B동 3층 중앙계단,AVAILABLE
+3b10,B동 3층 중앙계단,AVAILABLE
+3b11,B동 3층 중앙계단,AVAILABLE
+3b12,B동 3층 중앙계단,AVAILABLE
+3b13,B동 3층 중앙계단,AVAILABLE
+3b14,B동 3층 중앙계단,AVAILABLE
+3b15,B동 3층 중앙계단,AVAILABLE
+3b16,B동 3층 중앙계단,AVAILABLE
+3b17,B동 3층 중앙계단,AVAILABLE
+3b18,B동 3층 중앙계단,AVAILABLE
+1a01,B동 안뜰로 가는 통로,AVAILABLE
+1a02,B동 안뜰로 가는 통로,AVAILABLE
+1a03,B동 안뜰로 가는 통로,AVAILABLE
+1a04,B동 안뜰로 가는 통로,AVAILABLE
+1a05,B동 안뜰로 가는 통로,AVAILABLE
+1a06,B동 안뜰로 가는 통로,AVAILABLE
+1a07,B동 안뜰로 가는 통로,AVAILABLE
+1a08,B동 안뜰로 가는 통로,AVAILABLE
+1a09,B동 안뜰로 가는 통로,AVAILABLE
+1a10,B동 안뜰로 가는 통로,AVAILABLE
+1a11,B동 안뜰로 가는 통로,AVAILABLE
+1a12,B동 안뜰로 가는 통로,AVAILABLE
+1a13,B동 안뜰로 가는 통로,AVAILABLE
+1a14,B동 안뜰로 가는 통로,AVAILABLE
+1a15,B동 안뜰로 가는 통로,AVAILABLE
+1a16,B동 안뜰로 가는 통로,AVAILABLE
+1a17,B동 안뜰로 가는 통로,AVAILABLE
+1a18,B동 안뜰로 가는 통로,AVAILABLE
+1a19,B동 안뜰로 가는 통로,AVAILABLE
+1a20,B동 안뜰로 가는 통로,AVAILABLE
+1a21,B동 안뜰로 가는 통로,AVAILABLE
+1a22,B동 안뜰로 가는 통로,AVAILABLE
+1a23,B동 안뜰로 가는 통로,AVAILABLE
+1a24,B동 안뜰로 가는 통로,AVAILABLE
+1a25,B동 안뜰로 가는 통로,AVAILABLE
+1a26,B동 안뜰로 가는 통로,AVAILABLE
+1a27,B동 안뜰로 가는 통로,AVAILABLE
+1a28,B동 안뜰로 가는 통로,AVAILABLE
+1a29,B동 안뜰로 가는 통로,AVAILABLE
+1a30,B동 안뜰로 가는 통로,AVAILABLE
+1a31,B동 안뜰로 가는 통로,AVAILABLE
+1a32,B동 안뜰로 가는 통로,AVAILABLE
+1a33,B동 안뜰로 가는 통로,AVAILABLE
+1a34,B동 안뜰로 가는 통로,AVAILABLE
+1a35,B동 안뜰로 가는 통로,AVAILABLE
+1a36,B동 안뜰로 가는 통로,AVAILABLE
+1a37,B동 안뜰로 가는 통로,AVAILABLE
+1a38,B동 안뜰로 가는 통로,AVAILABLE
+1a39,B동 안뜰로 가는 통로,AVAILABLE
+1a40,B동 안뜰로 가는 통로,AVAILABLE
+1a41,B동 안뜰로 가는 통로,AVAILABLE
+1a42,B동 안뜰로 가는 통로,AVAILABLE
+1a43,B동 안뜰로 가는 통로,AVAILABLE
+1a44,B동 안뜰로 가는 통로,AVAILABLE
+1a45,B동 안뜰로 가는 통로,AVAILABLE
+1a46,B동 안뜰로 가는 통로,AVAILABLE
+1a47,B동 안뜰로 가는 통로,AVAILABLE
+1a48,B동 안뜰로 가는 통로,AVAILABLE
+1a49,B동 안뜰로 가는 통로,AVAILABLE
+1a50,B동 안뜰로 가는 통로,AVAILABLE
+1a51,B동 안뜰로 가는 통로,AVAILABLE
+1a52,B동 안뜰로 가는 통로,AVAILABLE
+1a53,B동 안뜰로 가는 통ロ,AVAILABLE
+1a54,B동 안뜰로 가는 통로,AVAILABLE
+1a55,B동 안뜰로 가는 통로,AVAILABLE
+1a56,B동 안뜰로 가는 통로,AVAILABLE
+1a57,B동 안뜰로 가는 통로,AVAILABLE
+3c01,C동 3층 경사로(352-2호 앞),AVAILABLE
+3c02,C동 3층 경사로(352-2호 앞),AVAILABLE
+3c03,C동 3층 경사로(352-2호 앞),AVAILABLE
+3c04,C동 3층 경사로(352-2호 앞),AVAILABLE
+3c05,C동 3층 경사로(352-2호 앞),AVAILABLE
+3c06,C동 3층 경사로(352-2호 앞),AVAILABLE
+3c07,C동 3층 경사로(352-2호 앞),AVAILABLE
+3c08,C동 3층 경사로(352-2호 앞),AVAILABLE
+3c09,C동 3층 경사로(352-2호 앞),AVAILABLE
+3c10,C동 3층 경사로(352-2호 앞),AVAILABLE
+3c11,C동 3층 경사로(352-2호 앞),AVAILABLE
+3c12,C동 3층 경사로(352-2호 앞),AVAILABLE
+3c13,C동 3층 경사로(352-2호 앞),AVAILABLE
+3c14,C동 3층 경사로(352-2호 앞),AVAILABLE
+3c15,C동 3층 경사로(352-2호 앞),AVAILABLE
+3c16,C동 3층 경사로(352-2호 앞),AVAILABLE
+3c17,C동 3층 경사로(352-2호 앞),AVAILABLE
+3c18,C동 3층 경사로(352-2호 앞),AVAILABLE
+3c19,C동 3층 경사로(352-2호 앞),AVAILABLE
+3c20,C동 3층 경사로(352-2호 앞),AVAILABLE
+3c21,C동 3층 경사로(352-2호 앞),AVAILABLE
+3c22,C동 3층 경사로(352-2호 앞),AVAILABLE
+3c23,C동 3층 경사로(352-2호 앞),AVAILABLE
+3c24,C동 3층 경사로(352-2호 앞),AVAILABLE
+3c25,C동 3층 경사로(352-2호 앞),AVAILABLE
+3c26,C동 3층 경사로(352-2호 앞),AVAILABLE
+3c27,C동 3층 경사로(352-2호 앞),AVAILABLE
+3c28,C동 3층 경사로(352-2호 앞),AVAILABLE
+3c29,C동 3층 경사로(352-2호 앞),AVAILABLE
+3c30,C동 3층 경사로(352-2호 앞),AVAILABLE
+3c31,C동 3층 경사로(352-2호 앞),AVAILABLE
+3c32,C동 3층 경사로(352-2호 앞),AVAILABLE
+3c33,C동 3층 경사로(352-2호 앞),AVAILABLE
+3c34,C동 3층 경사로(352-2호 앞),AVAILABLE
+3c35,C동 3층 경사로(352-2호 앞),AVAILABLE
+3c36,C동 3층 경사로(352-2호 앞),AVAILABLE
+3c37,C동 3층 중앙 계단,AVAILABLE
+3c38,C동 3층 중앙 계단,AVAILABLE
+3c39,C동 3층 중앙 계단,AVAILABLE
+3c40,C동 3층 중앙 계단,AVAILABLE
+3c41,C동 3층 중앙 계단,AVAILABLE
+3c42,C동 3층 중앙 계단,AVAILABLE
+3c43,C동 3층 중앙 계단,AVAILABLE
+3c44,C동 3층 중앙 계단,AVAILABLE
+3c45,C동 3층 중앙 계단,AVAILABLE
+3c46,C동 3층 중앙 계단,AVAILABLE
+3c47,C동 3층 중앙 계단,AVAILABLE
+3c48,C동 3층 중앙 계단,AVAILABLE
+3c49,C동 3층 중앙 계단,AVAILABLE
+3c50,C동 3층 중앙 계단,AVAILABLE
+3c51,C동 3층 중앙 계단,AVAILABLE
+3c52,C동 3층 중앙 계단,AVAILABLE
+3c53,C동 3층 중앙 계단,AVAILABLE
+3c54,C동 3층 중앙 계단,AVAILABLE
+3c55,C동 끝 3~4층 계단,AVAILABLE
+3c56,C동 끝 3~4층 계단,AVAILABLE
+3c57,C동 끝 3~4층 계단,AVAILABLE
+3c58,C동 끝 3~4층 계단,AVAILABLE
+3c59,C동 끝 3~4층 계단,AVAILABLE
+3c60,C동 끝 3~4층 계단,AVAILABLE
+3c61,C동 끝 3~4층 계단,AVAILABLE
+3c62,C동 끝 3~4층 계단,AVAILABLE
+3c63,C동 끝 3~4층 계단,AVAILABLE
+3c64,C동 끝 3~4층 계단,AVAILABLE
+3c65,C동 끝 3~4층 계단,AVAILABLE
+3c66,C동 끝 3~4층 계단,AVAILABLE
+3c67,C동 끝 3~4층 계단,AVAILABLE
+3c68,C동 끝 3~4층 계단,AVAILABLE
+3c69,C동 끝 3~4층 계단,AVAILABLE
+3c70,C동 끝 3~4층 계단,AVAILABLE
+3c71,C동 끝 3~4층 계단,AVAILABLE
+3c72,C동 끝 3~4층 계단,AVAILABLE
+3c73,C동 끝 3~4층 계단,AVAILABLE
+3c74,C동 끝 3~4층 계단,AVAILABLE
+3c75,C동 끝 3~4층 계단,AVAILABLE
+3c76,C동 끝 3~4층 계단,AVAILABLE
+3c77,C동 끝 3~4층 계단,AVAILABLE
+3c78,C동 끝 3~4층 계단,AVAILABLE
+3c79,C동 끝 3~4층 계단,AVAILABLE
+3c80,C동 끝 3~4층 계단,AVAILABLE
+3c81,C동 끝 3~4층 계단,AVAILABLE
+3c82,C동 끝 3~4층 계단,AVAILABLE
+3c83,C동 끝 3~4층 계단,AVAILABLE
+3c84,C동 끝 3~4층 계단,AVAILABLE
+3c85,C동 끝 3~4층 계단,AVAILABLE
+3c86,C동 끝 3~4층 계단,AVAILABLE
+3c87,C동 끝 3~4층 계단,AVAILABLE
+3c88,C동 끝 3~4층 계단,AVAILABLE
+3c89,C동 끝 3~4층 계단,AVAILABLE
+3c90,C동 끝 3~4층 계단,AVAILABLE
+3c91,C동 끝 3~4층 계단,AVAILABLE
+3c92,C동 끝 3~4층 계단,AVAILABLE
+3c93,C동 끝 3~4층 계단,AVAILABLE
+3c94,C동 끝 3~4층 계단,AVAILABLE
+3c95,C동 끝 3~4층 계단,AVAILABLE
+3c96,C동 끝 3~4층 계단,AVAILABLE
+3c97,C동 끝 3~4층 계단,AVAILABLE
+3c98,C동 끝 3~4층 계단,AVAILABLE
+3c99,C동 끝 3~4층 계단,AVAILABLE
+3c100,C동 끝 3~4층 계단,AVAILABLE
+3c101,C동 끝 3~4층 계단,AVAILABLE
+3c102,C동 끝 3~4층 계단,AVAILABLE
+3c103,C동 끝 3~4층 계단,AVAILABLE
+3c104,C동 끝 3~4층 계단,AVAILABLE
+3c105,C동 끝 3~4층 계단,AVAILABLE
+3c106,C동 끝 3~4층 계단,AVAILABLE
+3c107,C동 끝 3~4층 계단,AVAILABLE
+3c108,C동 끝 3~4층 계단,AVAILABLE
+3c109,C동 끝 3~4층 계단,AVAILABLE
+3c110,C동 끝 3~4층 계단,AVAILABLE
+3c111,C동 끝 3~4층 계단,AVAILABLE
+3c112,C동 끝 3~4층 계단,AVAILABLE
+3c113,C동 끝 3~4층 계단,AVAILABLE
+3c114,C동 끝 3~4층 계단,AVAILABLE
+3c115,C동 끝 3~4층 계단,AVAILABLE
+3c116,C동 끝 3~4층 계단,AVAILABLE
+3c117,C동 끝 3~4층 계단,AVAILABLE
+2c01,"A,C동 넘어가는 계단 앞",AVAILABLE
+2c02,"A,C동 넘어가는 계단 앞",AVAILABLE
+2c03,"A,C동 넘어가는 계단 앞",AVAILABLE
+2c04,"A,C동 넘어가는 계단 앞",AVAILABLE
+2c05,"A,C동 넘어가는 계단 앞",AVAILABLE
+2c06,"A,C동 넘어가는 계단 앞",AVAILABLE
+2c07,"A,C동 넘어가는 계단 앞",AVAILABLE
+2c08,"A,C동 넘어가는 계단 앞",AVAILABLE
+2c09,"A,C동 넘어가는 계단 앞",AVAILABLE
+2c10,"A,C동 넘어가는 계단 앞",AVAILABLE
+2c11,"A,C동 넘어가는 계단 앞",AVAILABLE
+2c12,"A,C동 넘어가는 계단 앞",AVAILABLE
+2c13,"A,C동 넘어가는 계단 앞",AVAILABLE
+2c14,"A,C동 넘어가는 계단 앞",AVAILABLE
+2c15,"A,C동 넘어가는 계단 앞",AVAILABLE
+2c16,"A,C동 넘어가는 계단 앞",AVAILABLE
+2c17,"A,C동 넘어가는 계단 앞",AVAILABLE
+2c18,"A,C동 넘어가는 계단 앞",AVAILABLE
+2c19,"A,C동 넘어가는 계단 앞",AVAILABLE
+2c20,"A,C동 넘어가는 계단 앞",AVAILABLE
+2c21,"A,C동 넘어가는 계단 앞",AVAILABLE
+2c22,"A,C동 넘어가는 계단 앞",AVAILABLE
+2c23,"A,C동 넘어가는 계단 앞",AVAILABLE
+2c24,"A,C동 넘어가는 계단 앞",AVAILABLE
+2c25,"A,C동 넘어가는 계단 앞",AVAILABLE
+2c26,"A,C동 넘어가는 계단 앞",AVAILABLE
+2c27,"A,C동 넘어가는 계단 앞",AVAILABLE


### PR DESCRIPTION
## 📚 개요

기존에 구글 폼으로 관리하던 사물함 대여 기능을 링커 프로젝트에 통합하여 구현했습니다 !

주요 변경 사항은 다음과 같습니다.
- 사물함 대여, 반납, 조회(전체/본인 사물함)를 위한 API를 구현했습니다.
- 관리자가 사물함의 상태(대여 중, 파손, 대여 전)를 변경할 수 있는 API를 추가했습니다.
- 데이터베이스에 locker 테이블 스키마를 추가했습니다.
- 애플리케이션 실행 시 초기 사물함 데이터가 자동으로 생성되도록 구현했는데,,,,, 사실 초기에 데이터를 어떻게 넣어야 하는지 몰라서 이렇게 구현했습니다. 이 부분 알려주시면 감사드리겠습니다

## 🕐 리뷰 예상 시간

> 10m ~ 15m

## ❗❗ 중요한 변경점(Option)

아래 파일들을 중심으로 리뷰해주시면 감사드리겠습니당

-   com.linker.linkerapi.locker/ : 사물함 기능의 핵심 로직이 모두 포함된 패키지입니당
-   resources/db/changelog/2025/09/13-01-changelog.yaml : 새로 추가된 locker 테이블의 스키마 정의 파일입니다
-   LinkerApiApplication.kt : 개발 환경에서 초기 사물함 데이터를 자동으로 생성해주는 CommandLineRunner를 추가했는데,, 어,, 이런식으로 데이터 넣는게 아닌 것 같습니다. 미리 죄송합니다.